### PR TITLE
改进 “Bangumi 国内放送站点链接” 以符合上游数据格式

### DIFF
--- a/imorz/bangumi-bgmlist.user.js
+++ b/imorz/bangumi-bgmlist.user.js
@@ -70,10 +70,11 @@ function addInfoRow(title, links) {
 }
 
 function addOnAirSites(bgm, sites) {
-  const links = bgm.sites.map(({site, id}) => {
+  const links = bgm.sites.map(({site, id, url}) => {
     const info = sites[site];
     if (!info) return;
-    const url = info.urlTemplate.replace('{{id}}', id);
+    if (!url)
+      url = info.urlTemplate.replace('{{id}}', id);
     return [url, info.title];
   }).filter(u => u);
   if (links.length)


### PR DESCRIPTION
上游 `bangumi-data/bangumi-data` 数据对不符合 `urlTemplate` 的情况采取 `url` 键临时代替原有 `id` 键。
对此进行兼容性处理。
主要影响范围为 A 站诸番。（最近地址内的 `ab` -> `aa`）