### PR TITLE
改了一下图标设计等（应mucc（略

### DIFF
--- a/cedar/TinyGrail_Income_Predictor_CedarVer.user.js
+++ b/cedar/TinyGrail_Income_Predictor_CedarVer.user.js
@@ -73,16 +73,16 @@ html[data-theme='dark'] a.badgeName:hover {
   right: 0;
   top: 0;
   bottom: 0;
-  width: 90%;
+  width: 80%;
   height: 90%;
   margin: auto;
-  background-color: rgba(0,0,0,0.9);
+  background-color: rgba(0,0,0,0.7);
   border-radius: 5px;
   z-index: 102;
 }
 #grailChart {
-  width: 70%;
-  min-width: 400px;
+  width: 80%;
+  min-width: 300px;
   margin: auto;
   overflow: auto;
 }
@@ -324,6 +324,7 @@ class IncomeAnalyser {
     this.$chartEl.empty();
 
     let labels, data, config;
+    let chartType = 'doughnut';
     this._templeStockNum;
     this._templeIncome;
 
@@ -336,26 +337,26 @@ class IncomeAnalyser {
     let stockNumChartEl = this._canvasEl.cloneNode(true);
     this.$chartEl.append(stockNumChartEl);
     [labels, data] = this._arrangeChartData(charaInfo, x => x.Name, x => x.State)
-    config = this._chartConfig(labels, data, 'pie', '角色持股分布', '角色持股量', findNthLargest(data));
+    config = this._chartConfig(labels, data, chartType, '角色持股分布', '角色持股量', findNthLargest(data));
     new ChartClass(stockNumChartEl, config);
 
     // chara income chart
     [labels, data] = this._arrangeChartData(charaInfo, x => x.Name, x => x.State*x.Rate)
-    config = this._chartConfig(labels, data.map(Math.round), 'pie', '角色股息分布', '角色股息', findNthLargest(data));
+    config = this._chartConfig(labels, data.map(Math.round), chartType, '角色股息分布', '角色股息', findNthLargest(data));
     let charaIncomeChartEl = this._canvasEl.cloneNode(true);
     this.$chartEl.append(charaIncomeChartEl);
     new ChartClass(charaIncomeChartEl, config);
 
     // temple stock num chart
     [labels, data] = this._arrangeChartData(this._templeInfo, x => x.Name, x => x.Sacrifices/2)
-    config = this._chartConfig(labels, data, 'pie', '圣殿计息持股分布', '圣殿计息持股量', findNthLargest(data));
+    config = this._chartConfig(labels, data, chartType, '圣殿计息持股分布', '圣殿计息持股量', findNthLargest(data));
     let templeStockNumChartEl = this._canvasEl.cloneNode(true);
     this.$chartEl.append(templeStockNumChartEl);
     new ChartClass(templeStockNumChartEl, config);
 
     // temple income chart
     [labels, data] = this._arrangeChartData(this._templeInfo, x => x.Name, x => x.Rate*x.Sacrifices/2)
-    config = this._chartConfig(labels, data.map(Math.round), 'pie', '圣殿股息分布', '圣殿股息', findNthLargest(data));
+    config = this._chartConfig(labels, data.map(Math.round), chartType, '圣殿股息分布', '圣殿股息', findNthLargest(data));
     let templeIncomeChartEl = this._canvasEl.cloneNode(true);
     this.$chartEl.append(templeIncomeChartEl);
     new ChartClass(templeIncomeChartEl, config);
@@ -406,7 +407,9 @@ class IncomeAnalyser {
         display: true,
         position: 'right',
         labels: {
-           filter: legendFilterFunc
+           filter: legendFilterFunc,
+           fontSize: 14,
+           fontColor: 'rgba(255,255,255,1)'
         }
       }
     };
@@ -415,12 +418,14 @@ class IncomeAnalyser {
       datasets: [{
         label: labelName,
         data: chartData,
-        backgroundColor: stepColor(chartData, '80%', '50%', '50%'),
-        borderColor: stepColor(chartData, '80%', '50%', '50%'),
-        borderWidth: 1,
-        hoverBackgroundColor: stepColor(chartData, '80%', '50%', '70%'),
-        hoverBorderColor: stepColor(chartData, '80%', '50%', '70%'),
-        hoverBorderWidth: 1
+        backgroundColor: stepColor(chartData, '95%', '70%', '100%'),
+        borderColor: 'rgba(0,0,0,0)',
+        borderWidth: 0,
+        hoverBackgroundColor: stepColor(chartData, '100%', '50%', '100%'),
+        hoverBorderColor: 'rgba(255,255,255,0.85)',
+        hoverBorderWidth: 5,
+        weight: 1,
+        borderAlign: 'inner'
       }]
     };
     let config = {

--- a/cedar/TinyGrail_Income_Predictor_CedarVer.user.js
+++ b/cedar/TinyGrail_Income_Predictor_CedarVer.user.js
@@ -73,16 +73,15 @@ html[data-theme='dark'] a.badgeName:hover {
   right: 0;
   top: 0;
   bottom: 0;
-  width: 80%;
-  height: 90%;
+  width: 100vmin;
+  height: 80vmin;
   margin: auto;
   background-color: rgba(0,0,0,0.7);
   border-radius: 5px;
   z-index: 102;
 }
 #grailChart {
-  width: 80%;
-  min-width: 300px;
+  width: 80vmin;
   margin: auto;
   overflow: auto;
 }
@@ -389,9 +388,12 @@ class IncomeAnalyser {
 */
 
   _chartConfig(labels, chartData, chartType, titleText, labelName, threshold) {
-    const total = chartData.reduce((sum, x) => sum + x);
+    // const total = chartData.reduce((sum, x) => sum + x);
+    const total = chartData.length;
+    const colorOffset = Math.floor(Math.random()*360);
     // using currying to access the previous value, then calculate hue value (shift 180deg)
-    const stepColor = (weights, s, l, a) => weights.map((sum => value => sum += value)(0)).map(x => `hsla(${parseInt((360/total*x+200)%360)},${s},${l},${a})`);
+    // const stepColor = (weights, s, l, a) => weights.map((sum => value => sum += value)(0)).map(x => `hsla(${parseInt((360/total*x+200)%360)},${s},${l},${a})`);
+    const stepColor = (weights, s, l, a) => weights.map((sum => () => sum += 1)(0)).map(x => `hsla(${parseInt((360/total*x+colorOffset)%360)},${s},${l},${a})`);
 
     //data.datasets[0].data[legendItem.index] >= threshold 时, 其 legend 才会在右侧显示出来
     const legendFilterFunc = (legendItem, data) => data.datasets[0].data[legendItem.index] >= threshold;
@@ -401,7 +403,9 @@ class IncomeAnalyser {
       maintainAspectRatio: true,
       title: {
         display: true,
-        text: titleText
+        text: titleText,
+        fontSize: 18,
+        fontColor: "#fff"
       },
       legend: {
         display: true,


### PR DESCRIPTION
主要改了饼图的尺寸、颜色分布。

饼图尺寸改成和窗口长宽中的最小值相关了。

持股数值小的条目本就都聚在一起，之前的取色方式会让它们的颜色还非常接近，有些看不清、个人觉得。

刚刚才发现我不是基于你最新的commit修改的，有点尴尬。chart title那里我也改了，和现在的版本不太一样。