### PR TITLE
fix: word counter not shown in subject page

### DIFF
--- a/cedar/comment_word_counter.user.js
+++ b/cedar/comment_word_counter.user.js
@@ -37,7 +37,7 @@ function createWordCounter(dom = document) {
   let wrapper = document.createElement('div');
   wrapper.style.fontWeight = 'bold';
   wrapper.append(wordcounter, '/', limit);
-  dom.querySelector('textarea').insertAdjacentElement('afterend', wrapper);
+  comment.insertAdjacentElement('afterend', wrapper);
 
   comment.addEventListener('input', e => {
     let count = e.target.value.length;


### PR DESCRIPTION
When used as widget, `document.querySelector('textarea')` returns "textarea#Out_text" instead of "textarea#comment"