### PR TITLE
修改Bangumi_Collect_Easy_Edit中securitycode变量的取值逻辑

### DIFF
--- a/liaune/Bangumi_Collect_Easy_Edit.user.js
+++ b/liaune/Bangumi_Collect_Easy_Edit.user.js
@@ -31,7 +31,7 @@ class BgmCollections {
 	}
 	init(){
 		// $('#browserTools').append('<a id="saveCollect" class="chiiBtn" href="#">保存修改</a>');
-		let securitycode = $('#badgeUserPanel a[href*="logout"]')[0].href.split('/logout/')[1].toString();
+		let securitycode = document.querySelector('#browserItemList .collectBlock a:last-of-type').getAttribute('onclick').slice(-10, -2);
 		let interest = this.get_interest();
 		let itemsList = document.querySelectorAll('#browserItemList li.item');
 		itemsList.forEach( (elem, i) =>{

--- a/liaune/Bangumi_Collect_Easy_Edit.user.js
+++ b/liaune/Bangumi_Collect_Easy_Edit.user.js
@@ -5,7 +5,7 @@
 // @license      MIT
 // @description  在收藏页面点击“Edit”即可修改收藏条目的状态，评分，标签，评论等信息，可单项修改，随改随存。
 // @include      /^https?://(bangumi\.tv|bgm\.tv|chii\.in)\/\S+\/list\/\S+\/(wish|collect|do|on_hold|dropped).*
-// @version      1.4
+// @version      1.4.1
 // @grant        GM_addStyle
 // ==/UserScript==
 GM_addStyle(`

--- a/liaune/Bangumi_Collect_Easy_Edit.user.js
+++ b/liaune/Bangumi_Collect_Easy_Edit.user.js
@@ -31,7 +31,7 @@ class BgmCollections {
 	}
 	init(){
 		// $('#browserTools').append('<a id="saveCollect" class="chiiBtn" href="#">保存修改</a>');
-		let securitycode = document.querySelector('#browserItemList .collectBlock a:last-of-type').getAttribute('onclick').slice(-10, -2);
+		let securitycode = document.querySelector('#browserItemList .collectBlock a:last-of-type').getAttribute('onclick').match(/'(.+)'/)[1];
 		let interest = this.get_interest();
 		let itemsList = document.querySelectorAll('#browserItemList li.item');
 		itemsList.forEach( (elem, i) =>{


### PR DESCRIPTION
我的隐藏登出按钮(hide_logout.user.js)把登出按钮的链接改掉了，导致代码出错
建议securitycode从“删除”链接里获取，这样会稳定一点